### PR TITLE
Add docker compose volumes to persist data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ log.out
 
 # Ignore integration workspace
 workspace/
+
+# Ignore Docker-related files
+outputs/
+favorites/

--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,3 @@ log.out
 
 # Ignore integration workspace
 workspace/
-
-# Ignore Docker-related files
-outputs/
-favorites/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,15 @@ services:
       # include React UI
       - ${UI_PORT:-3000}:3000
     container_name: tts-webui
+    volumes:
+      - ./data:/app/tts-webui/data
+      - ./outputs:/app/tts-webui/outputs
+      - ./favorites:/app/tts-webui/favorites
+    # environment:
+    #   # Disable hard requirements for CUDA version ("requirement error: unsatisfied condition [...]")
+    #   # This might still lead to errors but allows to run some models even if CUDA version is not met
+    #   # https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#nvidia-disable-require-environment-variable
+    #   NVIDIA_DISABLE_REQUIRE: 1 
     deploy:
         resources:
           reservations:


### PR DESCRIPTION
Add outputs and favorites volume to prevent losing on container restart. As mentioned by your comment https://github.com/rsxdalv/TTS-WebUI/issues/516#issuecomment-2935657811. 

There are still some issues:
- Outputs are not showing up in the ReactUI (http://localhost:3000/outputs) but work in the Gradio UI
- Outputs are listed in history but cannot be interacted with

Is there a way to persist extensions? Persisting the `extensions` folder does not seem to do the trick.

Add document for `NVIDIA_DISABLE_REQUIRE` which can be useful for older hardware/drivers/CUDA toolkit. It does not magically makes it retro-compatible but at least allows the webUI to start and run some models.
