### PR TITLE
[react-ui] Prepend `voices/chatterbox` to voice file selection in ap test page #542

### DIFF
--- a/react-ui/src/pages/tools/_api_config.tsx
+++ b/react-ui/src/pages/tools/_api_config.tsx
@@ -798,7 +798,10 @@ export default function VoiceConfigGenerator() {
                               <SelectContent>
                                 <SelectItem value="unset">Unset</SelectItem>
                                 {availableChatterboxVoices.map((voice) => (
-                                  <SelectItem key={voice} value={voice}>
+                                  <SelectItem
+                                    key={voice}
+                                    value={`voices/chatterbox/${voice}`}
+                                  >
                                     {voice.replace(".wav", "")}
                                   </SelectItem>
                                 ))}


### PR DESCRIPTION

## Root Cause Analysis

The error occurs because:

1. The application attempts to load `Sloane.wav` from the current working directory
2. The actual voice files are stored in the `voices/chatterbox` directory
3. The React UI config generator doesn't prepend the correct path to voice file selections

## Proposed Solution

Update the React UI config generator code to:

1. Prepend the correct base path `voices/chatterbox/` to voice file selections
2. This will update the configuration to use the correct relative path

### Configuration Changes

Before:

```json
"audio_prompt_path": "Sloane.wav"
```

After:

```json
"audio_prompt_path": "voices/chatterbox/Sloane.wav"
```

## Verification

After implementing the fix:

1. The TTS generation works successfully
2. The system correctly loads the reference audio file from:
   ```
   'audio_prompt_path': 'voices/chatterbox/Sloane.wav'
   ```
3. Output shows successful generation:
   ```
   Using chatterbox with params: ('Hello, this is a test of the voice synthesis.', {'exaggeration': 0.5, 'cfg_weight': 0.5, 'temperature': 0.8, 'model_name': 'just_a_placeholder', 'device': 'auto', 'dtype': 'bfloat16', 'audio_prompt_path': 'voices/chatterbox/Sloane.wav'}), {}
   Using device: cuda
   Using cached model 'Chatterbox on cuda with torch.bfloat16' in namespace 'chatterbox'.
   Generating chunk: Hello, this is a test of the voice synthesis.
   Estimated token count: 66
   Sampling:  12%|█▏        | 120/1000 [00:02<00:19, 45.02it/s]
   ```