### PR TITLE
Fix #647: Add: Step_Audio_EditX_TTS, FishAudioS2, SoulX-Singer & Stab...

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -500,6 +500,34 @@
                 "website": "https://github.com/rsxdalv/tts_webui_extension.megatts3",
                 "extension_website": "https://github.com/rsxdalv/tts_webui_extension.megatts3",
                 "extension_platform_version": "0.0.1"
+            },
+            {
+                "package_name": "tts_webui_extension.step_audio_editx_tts",
+                "name": "Step-Audio EditX TTS (Beta)",
+                "requirements": "git+https://github.com/rsxdalv/tts_webui_extension.step_audio_editx_tts@main",
+                "description": "Step-Audio EditX TTS is a text-to-speech model with audio editing capabilities",
+                "extension_type": "interface",
+                "extension_class": "text-to-speech",
+                "author": "stepfun-ai",
+                "extension_author": "rsxdalv",
+                "license": "MIT",
+                "website": "https://github.com/stepfun-ai/Step-Audio",
+                "extension_website": "https://github.com/rsxdalv/tts_webui_extension.step_audio_editx_tts",
+                "extension_platform_version": "0.0.1"
+            },
+            {
+                "package_name": "tts_webui_extension.fish_audio_s2",
+                "name": "Fish Audio S2 (Beta)",
+                "requirements": "git+https://github.com/rsxdalv/tts_webui_extension.fish_audio_s2@main",
+                "description": "Fish Audio S2 is a high-quality text-to-speech and voice cloning model",
+                "extension_type": "interface",
+                "extension_class": "text-to-speech",
+                "author": "fishaudio",
+                "extension_author": "rsxdalv",
+                "license": "MIT",
+                "website": "https://github.com/fishaudio/fish-speech",
+                "extension_website": "https://github.com/rsxdalv/tts_webui_extension.fish_audio_s2",
+                "extension_platform_version": "0.0.1"
             }
         ],
         "audio-music-generation": [
@@ -601,6 +629,34 @@
                 "license": "MIT",
                 "website": "https://github.com/rsxdalv/tts_webui_extension.songbloom",
                 "extension_website": "https://github.com/rsxdalv/tts_webui_extension.songbloom",
+                "extension_platform_version": "0.0.1"
+            },
+            {
+                "package_name": "tts_webui_extension.soulx_singer",
+                "name": "SoulX Singer (Beta)",
+                "requirements": "git+https://github.com/rsxdalv/tts_webui_extension.soulx_singer@main",
+                "description": "SoulX Singer is a singing voice synthesis model for generating high-quality vocal audio",
+                "extension_type": "interface",
+                "extension_class": "audio-music-generation",
+                "author": "SoulX",
+                "extension_author": "rsxdalv",
+                "license": "MIT",
+                "website": "https://github.com/Saganaki22/ComfyUI-SoulX-Singer",
+                "extension_website": "https://github.com/rsxdalv/tts_webui_extension.soulx_singer",
+                "extension_platform_version": "0.0.1"
+            },
+            {
+                "package_name": "tts_webui_extension.stable_audio_x",
+                "name": "StableAudioX (Beta)",
+                "requirements": "git+https://github.com/rsxdalv/tts_webui_extension.stable_audio_x@main",
+                "description": "StableAudioX is an extended text-to-audio model for generating music and sound effects",
+                "extension_type": "interface",
+                "extension_class": "audio-music-generation",
+                "author": "Stability AI",
+                "extension_author": "rsxdalv",
+                "license": "MIT",
+                "website": "https://github.com/lum3on/ComfyUI-StableAudioX",
+                "extension_website": "https://github.com/rsxdalv/tts_webui_extension.stable_audio_x",
                 "extension_platform_version": "0.0.1"
             }
         ],


### PR DESCRIPTION
Closes #647

## Before

`extensions.json` contained no entries for Step-Audio EditX TTS or Fish Audio S2 in the `text-to-speech` section, and no entries for SoulX Singer or StableAudioX in the `audio-music-generation` section. Users had no way to install these four models through the TTS WebUI extension manager.

## After

Four new extension entries are registered in `extensions.json`:

**text-to-speech section** (after the `megatts3` entry, lines ~503–528):
- `tts_webui_extension.step_audio_editx_tts` — Step-Audio EditX TTS (Beta), backed by `stepfun-ai/Step-Audio`, installed from `rsxdalv/tts_webui_extension.step_audio_editx_tts@main`
- `tts_webui_extension.fish_audio_s2` — Fish Audio S2 (Beta), backed by `fishaudio/fish-speech`, installed from `rsxdalv/tts_webui_extension.fish_audio_s2@main`

**audio-music-generation section** (after the `songbloom` entry, lines ~633–658):
- `tts_webui_extension.soulx_singer` — SoulX Singer (Beta), installed from `rsxdalv/tts_webui_extension.soulx_singer@main`
- `tts_webui_extension.stable_audio_x` — StableAudioX (Beta), backed by Stability AI's AudioX model, installed from `rsxdalv/tts_webui_extension.stable_audio_x@main`

All four entries are marked Beta, use `"extension_type": "interface"`, carry MIT licenses, and follow the existing schema structure (`package_name`, `name`, `requirements`, `description`, `extension_type`, `extension_class`, `author`, `extension_author`, `license`, `website`, `extension_website`, `extension_platform_version`).

## Changes

- `extensions.json`: Added 2 entries to `text-to-speech` array and 2 entries to `audio-music-generation` array. No other files modified.

## Testing

1. Load the extension manager in TTS WebUI and confirm all four extensions appear in their respective categories.
2. Install each extension individually and verify the pip install resolves against the correct `@main` branch of each `rsxdalv/tts_webui_extension.*` repo.
3. Confirm JSON validity: `python -m json.tool extensions.json` exits 0.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*